### PR TITLE
feat: encrypt OAuth tokens and link to user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables
+# Generate a 32-byte key: `openssl rand -base64 32`
+TOKEN_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out
 
 # Env
 .env*
+!.env.example
 
 # OS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev build start lint worker supabase-start db-reset
+.PHONY: setup dev build start lint test worker supabase-start db-reset
 
 setup:
 	corepack enable || true
@@ -15,7 +15,10 @@ start:
 	npm run start
 
 lint:
-	npm run lint || true
+        npm run lint || true
+
+test:
+        npm test
 
 worker:
 	npm run worker:dev

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ npm run db:reset
 npm run worker:dev
 
 ## Notes (OAuth tokens persistence)
-- `/api/gbp/callback` は取得した tokens を `oauth_tokens` テーブルへ保存します（`supabase/migrations/0002_oauth_tokens.sql`）。
-- 開発用の簡易保存です。本番では KMS/Secrets 等で暗号化し、ユーザ/テナントに紐付けてください。
+- `/api/gbp/callback` は取得した tokens を暗号化し `oauth_tokens` テーブルへ保存します（`supabase/migrations/0003_encrypted_oauth_tokens.sql`）。
+- 暗号化には `TOKEN_ENCRYPTION_KEY`（Base64 32バイト）を使用します。
 ```
 
 ## Env
 
 - `.env.local` を Next.js 用に使用
 - `.env` は worker 用（同値でも可）
+- `TOKEN_ENCRYPTION_KEY` を Base64 32バイトで設定（`openssl rand -base64 32`）
 
 ## Deploy
 

--- a/app/api/gbp/callback/route.ts
+++ b/app/api/gbp/callback/route.ts
@@ -1,25 +1,36 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { oauth2Client } from '@/lib/google';
-import { query } from '@/lib/db';
+import * as db from '@/lib/db';
+import { encrypt } from '@/src/lib/crypto';
 
-export async function GET(req: NextRequest) {
+export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get('code');
-  if (!code) return NextResponse.json({ error: 'missing code' }, { status: 400 });
+  if (!code) return Response.json({ error: 'missing code' }, { status: 400 });
+
+  const userId = req.headers.get('x-user-id');
+  if (!userId) return Response.json({ error: 'missing user' }, { status: 401 });
 
   const { tokens } = await oauth2Client.getToken(code);
-  // NOTE: 実運用では KMS 等で暗号化保管し、ユーザ/テナントにひも付けます。
+  let encrypted: Buffer;
+  try {
+    encrypted = encrypt(tokens);
+  } catch (e) {
+    return Response.json(
+      { error: `encrypt failed: ${(e as Error).message}` },
+      { status: 500 }
+    );
+  }
   try {
     if (!process.env.SUPABASE_DB_URL) {
       throw new Error('SUPABASE_DB_URL not set');
     }
-    await query(
-      'insert into oauth_tokens (provider, tokens) values ($1, $2)',
-      ['google', tokens as unknown as Record<string, unknown>]
+    await db.query(
+      'insert into oauth_tokens (provider, user_id, encrypted_tokens) values ($1, $2, $3)',
+      ['google', userId, encrypted]
     );
   } catch (e) {
     // 保存に失敗しても、開発フェーズでは結果を返して状況確認できるようにします。
-    return NextResponse.json({ ok: true, tokens, persisted: false, error: (e as Error).message });
+    return Response.json({ ok: true, tokens, persisted: false, error: (e as Error).message });
   }
-  return NextResponse.json({ ok: true, tokens, persisted: true });
+  return Response.json({ ok: true, tokens, persisted: true });
 }

--- a/docs/gcp-oauth-setup.md
+++ b/docs/gcp-oauth-setup.md
@@ -19,6 +19,7 @@
 GOOGLE_OAUTH_CLIENT_ID=...
 GOOGLE_OAUTH_CLIENT_SECRET=...
 GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3014/api/gbp/callback
+TOKEN_ENCRYPTION_KEY=openssl rand -base64 32 で生成
 ```
 
 ## 4) 動作確認

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "dev": "next dev -p 3014",
     "build": "next build",
     "start": "next start -p 3014",
-    "lint": "next lint",
-    "worker:dev": "tsx watch worker/gbp-worker.ts",
-    "supabase:start": "supabase start",
-    "db:reset": "supabase db reset --db-url ${SUPABASE_DB_URL:-postgresql://postgres:postgres@localhost:54322/postgres}"
+    "lint": "next lint", 
+    "worker:dev": "tsx watch worker/gbp-worker.ts", 
+    "supabase:start": "supabase start", 
+    "db:reset": "supabase db reset --db-url ${SUPABASE_DB_URL:-postgresql://postgres:postgres@localhost:54322/postgres}",
+    "test": "tsx --test tests/api/gbp/callback.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,35 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96 bits for GCM
+
+function get_key() {
+  const key = process.env.TOKEN_ENCRYPTION_KEY
+    ? Buffer.from(process.env.TOKEN_ENCRYPTION_KEY, 'base64')
+    : Buffer.alloc(0);
+  if (key.length !== 32) {
+    throw new Error('TOKEN_ENCRYPTION_KEY must be 32 bytes base64');
+  }
+  return key;
+}
+
+export function encrypt(data: unknown): Buffer {
+  const key = get_key();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const json = JSON.stringify(data);
+  const enc = Buffer.concat([cipher.update(json, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, enc]);
+}
+
+export function decrypt(payload: Buffer): unknown {
+  const key = get_key();
+  const iv = payload.subarray(0, IV_LENGTH);
+  const tag = payload.subarray(IV_LENGTH, IV_LENGTH + 16);
+  const text = payload.subarray(IV_LENGTH + 16);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([decipher.update(text), decipher.final()]);
+  return JSON.parse(dec.toString('utf8'));
+}

--- a/supabase/migrations/0003_encrypted_oauth_tokens.sql
+++ b/supabase/migrations/0003_encrypted_oauth_tokens.sql
@@ -1,0 +1,10 @@
+-- Add user_id and encrypted_tokens, drop plain tokens
+alter table oauth_tokens
+  add column if not exists user_id uuid,
+  add column if not exists encrypted_tokens bytea;
+
+alter table oauth_tokens
+  drop column if exists tokens;
+
+create index if not exists idx_oauth_tokens_user_id_created_at
+  on oauth_tokens(user_id, created_at desc);

--- a/tests/api/gbp/callback.test.ts
+++ b/tests/api/gbp/callback.test.ts
@@ -1,0 +1,36 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { oauth2Client } from '@/lib/google';
+import { pool } from '@/lib/db';
+
+process.env.TOKEN_ENCRYPTION_KEY = Buffer.alloc(32).toString('base64');
+process.env.SUPABASE_DB_URL = 'postgres://localhost/test';
+
+const { GET } = await import('@/app/api/gbp/callback/route');
+const { decrypt } = await import('@/src/lib/crypto');
+
+test('tokens are encrypted before persistence', async () => {
+  const sample = { access_token: 'a', refresh_token: 'r' };
+  mock.method(oauth2Client, 'getToken', async () => ({ tokens: sample }));
+  let saved: any;
+  mock.method(pool, 'connect', async () => ({
+    query: async (_text: string, params: any[]) => {
+      saved = params[2];
+      return { rows: [] } as any;
+    },
+    release() {}
+  } as any));
+
+  const req = new Request('http://localhost/api/gbp/callback?code=xyz', {
+    headers: { 'x-user-id': '123e4567-e89b-12d3-a456-426614174000' }
+  });
+  const res = await GET(req);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.tokens, sample);
+  assert.ok(body.persisted);
+  assert.ok(Buffer.isBuffer(saved));
+  assert.notDeepEqual(saved, sample);
+  const decoded = decrypt(saved);
+  assert.deepEqual(decoded, sample);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,8 @@
   "include": [
     "app",
     "lib",
+    "src",
+    "tests",
     "next-env.d.ts",
     "worker",
     ".next/types/**/*.ts"


### PR DESCRIPTION
## Summary
- add AES-GCM utilities for encrypt/decrypt
- store encrypted tokens tied to user in oauth_tokens table
- document TOKEN_ENCRYPTION_KEY setup and add regression test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae3ae5e93c832aa202d91fb0258518