### PR TITLE
feat(tokens): implement refresh token workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev build start lint worker supabase-start db-reset
+.PHONY: setup dev build start lint worker supabase-start db-reset test
 
 setup:
 	corepack enable || true
@@ -15,10 +15,13 @@ start:
 	npm run start
 
 lint:
-	npm run lint || true
+        npm run lint || true
 
 worker:
-	npm run worker:dev
+        npm run worker:dev
+
+test:
+        npm test || true
 
 supabase-start:
 	npm run supabase:start

--- a/app/api/gbp/callback/route.ts
+++ b/app/api/gbp/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { oauth2Client } from '@/lib/google';
 import { query } from '@/lib/db';
+import { encrypt } from '@/lib/crypto';
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -8,14 +9,17 @@ export async function GET(req: NextRequest) {
   if (!code) return NextResponse.json({ error: 'missing code' }, { status: 400 });
 
   const { tokens } = await oauth2Client.getToken(code);
+  const { refresh_token, expiry_date } = tokens;
+  const expiresAt = expiry_date ? new Date(expiry_date) : null;
+  const encryptedRefresh = refresh_token ? encrypt(refresh_token) : null;
   // NOTE: 実運用では KMS 等で暗号化保管し、ユーザ/テナントにひも付けます。
   try {
     if (!process.env.SUPABASE_DB_URL) {
       throw new Error('SUPABASE_DB_URL not set');
     }
     await query(
-      'insert into oauth_tokens (provider, tokens) values ($1, $2)',
-      ['google', tokens as unknown as Record<string, unknown>]
+      'insert into oauth_tokens (provider, tokens, refresh_token, expires_at) values ($1, $2, $3, $4)',
+      ['google', tokens as unknown as Record<string, unknown>, encryptedRefresh, expiresAt]
     );
   } catch (e) {
     // 保存に失敗しても、開発フェーズでは結果を返して状況確認できるようにします。

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,0 +1,26 @@
+import crypto from 'crypto';
+
+const ALGO = 'aes-256-gcm';
+const KEY = crypto
+  .createHash('sha256')
+  .update(process.env.TOKEN_ENC_KEY || 'development-key')
+  .digest();
+
+export function encrypt(plain: string): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGO, KEY, iv);
+  const enc = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, enc]).toString('base64');
+}
+
+export function decrypt(payload: string): string {
+  const data = Buffer.from(payload, 'base64');
+  const iv = data.subarray(0, 12);
+  const tag = data.subarray(12, 28);
+  const text = data.subarray(28);
+  const decipher = crypto.createDecipheriv(ALGO, KEY, iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([decipher.update(text), decipher.final()]);
+  return dec.toString('utf8');
+}

--- a/lib/token_refresh.ts
+++ b/lib/token_refresh.ts
@@ -1,0 +1,28 @@
+import { oauth2Client } from './google';
+import { query } from './db';
+import { decrypt, encrypt } from './crypto';
+
+export const REFRESH_THRESHOLD_MS = 10 * 60 * 1000;
+
+export function should_refresh(expiresAt: Date, now = new Date()): boolean {
+  return expiresAt.getTime() - now.getTime() < REFRESH_THRESHOLD_MS;
+}
+
+export async function refresh_tokens(
+  row: { id: string; refresh_token: string },
+  deps: { oauth2Client?: typeof oauth2Client; query?: typeof query } = {}
+) {
+  const o = deps.oauth2Client || oauth2Client;
+  const q = deps.query || query;
+  const refreshToken = decrypt(row.refresh_token);
+  o.setCredentials({ refresh_token: refreshToken });
+  const { credentials } = await o.refreshAccessToken();
+  const { refresh_token, expiry_date } = credentials;
+  const expiresAt = expiry_date ? new Date(expiry_date) : null;
+  const encrypted = refresh_token ? encrypt(refresh_token) : row.refresh_token;
+  await q(
+    'update oauth_tokens set tokens=$1, refresh_token=$2, expires_at=$3 where id=$4',
+    [credentials as unknown as Record<string, unknown>, encrypted, expiresAt, row.id]
+  );
+  return { tokens: credentials, expires_at: expiresAt };
+}

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "start": "next start -p 3014",
     "lint": "next lint",
     "worker:dev": "tsx watch worker/gbp-worker.ts",
+    "worker:refresh": "tsx watch worker/token-refresher.ts",
     "supabase:start": "supabase start",
-    "db:reset": "supabase db reset --db-url ${SUPABASE_DB_URL:-postgresql://postgres:postgres@localhost:54322/postgres}"
+    "db:reset": "supabase db reset --db-url ${SUPABASE_DB_URL:-postgresql://postgres:postgres@localhost:54322/postgres}",
+    "test": "node --test --import tsx tests/**/*.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",

--- a/supabase/migrations/0003_oauth_tokens_refresh.sql
+++ b/supabase/migrations/0003_oauth_tokens_refresh.sql
@@ -1,0 +1,9 @@
+-- add refresh token and expiry tracking
+alter table oauth_tokens
+  add column refresh_token text,
+  add column expires_at timestamptz;
+
+-- backfill expires_at from stored tokens if present
+update oauth_tokens
+set expires_at = to_timestamp((tokens->>'expiry_date')::bigint / 1000)
+where tokens ? 'expiry_date' and expires_at is null;

--- a/tests/lib/token_refresh.test.ts
+++ b/tests/lib/token_refresh.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { refresh_tokens, should_refresh } from '../../lib/token_refresh.ts';
+import { encrypt, decrypt } from '../../lib/crypto.ts';
+
+test('refresh_tokens updates record', async () => {
+  const client = {
+    setCredentials: () => {},
+    refreshAccessToken: async () => ({
+      credentials: {
+        access_token: 'new',
+        refresh_token: 'newref',
+        expiry_date: 1000
+      }
+    })
+  } as any;
+  const calls: any[] = [];
+  const q = async (text: string, params: any[]) => {
+    calls.push({ text, params });
+    return { rows: [] };
+  };
+  const row = { id: '1', refresh_token: encrypt('oldref') };
+  await refresh_tokens(row, { oauth2Client: client, query: q });
+  assert.equal(calls.length, 1);
+  const p = calls[0].params;
+  assert.equal(decrypt(p[1]), 'newref');
+  assert.equal(p[2] instanceof Date && p[2].getTime() === 1000, true);
+});
+
+test('refresh_tokens propagates error', async () => {
+  const client = {
+    setCredentials: () => {},
+    refreshAccessToken: async () => {
+      throw new Error('fail');
+    }
+  } as any;
+  const q = async () => ({ rows: [] });
+  const row = { id: '1', refresh_token: encrypt('oldref') };
+  await assert.rejects(() => refresh_tokens(row, { oauth2Client: client, query: q }), /fail/);
+});
+
+test('should_refresh detects expiration', () => {
+  const now = new Date();
+  const soon = new Date(now.getTime() + 5 * 60 * 1000);
+  const later = new Date(now.getTime() + 20 * 60 * 1000);
+  assert.equal(should_refresh(soon, now), true);
+  assert.equal(should_refresh(later, now), false);
+});

--- a/worker/token-refresher.ts
+++ b/worker/token-refresher.ts
@@ -1,0 +1,32 @@
+import PgBoss from 'pg-boss';
+import { query } from '../lib/db';
+import { refresh_tokens, should_refresh } from '../lib/token_refresh';
+
+const DATABASE_URL =
+  process.env.SUPABASE_DB_URL || 'postgres://postgres:postgres@localhost:54322/postgres';
+const boss = new PgBoss(DATABASE_URL);
+
+async function scan() {
+  const res = await query(
+    'select id, refresh_token, expires_at from oauth_tokens where refresh_token is not null'
+  );
+  const now = new Date();
+  for (const row of res.rows) {
+    if (row.expires_at && should_refresh(new Date(row.expires_at), now)) {
+      await refresh_tokens({ id: row.id, refresh_token: row.refresh_token });
+    }
+  }
+}
+
+async function main() {
+  await boss.start();
+  await boss.schedule('tokens.refresh', '*/5 * * * *');
+  await boss.work('tokens.refresh', async () => {
+    await scan();
+  });
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add refresh_token and expires_at columns via migration
- encrypt refresh tokens and store expiry on callback
- add refresh utility, worker job, and tests

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3ccd48a0832a8fee141830372c60